### PR TITLE
Fix: Localize Datepickk calendar to Brazilian Portuguese

### DIFF
--- a/js/app/calendar.js
+++ b/js/app/calendar.js
@@ -58,6 +58,7 @@ function initCalendar() {
     var calendar = new Datepickk({
         container: calendarDiv,
         inline: true,
+        lang: 'pt-br', // Set language to Brazilian Portuguese
         range: true, // Note: Range true might affect onSelect behavior for single date selection intent
         tooltips: datepickkTooltips, // Use dynamically generated tooltips
         highlight: { // Keep existing highlight logic or adjust as needed

--- a/js/datepickk.js
+++ b/js/datepickk.js
@@ -120,6 +120,11 @@ function Datepickk(args) {
 			monthNames: ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'],
 			dayNames: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
 			weekStart: 1
+		},
+		'pt-br': {
+			monthNames: ['Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro'],
+			dayNames: ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb'],
+			weekStart: 0
 		}
 	};
 


### PR DESCRIPTION
This commit adds Brazilian Portuguese (pt-BR) localization to the Datepickk library and configures the calendar instance to use it. This ensures that month names and day-of-the-week headers within the calendar widget are displayed in Portuguese.

This corrects an oversight from the initial translation where the Datepickk component itself was not localized.

The following files were modified:
- js/datepickk.js: Added 'pt-br' to the internal languages object.
- js/app/calendar.js: Set 'lang: "pt-br"' in Datepickk options.