### PR TITLE
Fix: More robust Datepickk localization for pt-BR

### DIFF
--- a/js/app/calendar.js
+++ b/js/app/calendar.js
@@ -104,6 +104,7 @@ function initCalendar() {
             }
         }
     });
+    calendar.lang = 'pt-br'; // Explicitly set lang again after instantiation
     calendarDiv.classList.add('datepickk-initialized');
 
     // Add Event Listener for the "Save Event" button


### PR DESCRIPTION
This commit attempts a more robust way to set the
Brazilian Portuguese language for the Datepickk calendar.

Changes:
- In js/app/calendar.js, explicitly set `calendar.lang = 'pt-br';` immediately after the Datepickk instance is created. This is in addition to setting it in the constructor, aiming to ensure the language setter is triggered correctly.
- The js/datepickk.js file should still contain the 'pt-br' language definition added previously.

This is to address an issue where calendar month and day names were still appearing in English.