### PR TITLE
Refine UI: Adjust field sizes and implement dark mode.

### DIFF
--- a/css/main-theme.css
+++ b/css/main-theme.css
@@ -226,3 +226,406 @@ body {
 .event-list-container .event-item .panel-body p strong {
     color: #333; /* Ensure strong tags are sufficiently dark */
 }
+
+/* Event Modal Field Adjustments */
+#eventStartTimeInput,
+#eventEndTimeInput {
+    width: auto;
+    min-width: 120px;
+    max-width: 150px; /* Or consider using Bootstrap col classes for layout */
+}
+
+#eventDescriptionInput {
+    min-height: 100px; /* Provides more space than default rows="3" */
+}
+
+#reminderValueInput {
+    /* width: auto; */ /* form-control by default is width: 100% of its container */
+    min-width: 80px; /* Ensures it's not too crunched */
+    /* max-width: 100px; /* Limits excessive width if container is too large, though col-xs-5 handles this */
+}
+
+#reminderUnitInput {
+    /* width: auto; */ /* form-control by default is width: 100% of its container */
+    min-width: 120px; /* Accommodates longer text like "Minutos Antes" */
+    /* max-width: 180px; /* Limits excessive width, col-xs-5 also contributes */
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #212529 !important; /* Dark gray, using !important to override existing !important */
+        color: #e0e0e0; /* Light gray text */
+    }
+
+    #main-content-area {
+        background-color: #212529; /* Ensure main content area also has dark background if it's styled separately */
+        /* If #main-content-area inherits body background, this might not be needed unless it has its own light background */
+    }
+
+    /* Navbar */
+    .navbar-default {
+        background-color: #343a40; /* Darker gray for navbar */
+        border-color: #454d55; /* Slightly lighter border for dark navbar */
+    }
+
+    .navbar-default .navbar-brand {
+        color: #f8f9fa; /* White/very light gray for brand */
+    }
+
+    .navbar-default .navbar-brand:hover,
+    .navbar-default .navbar-brand:focus {
+        color: #ced4da; /* Lighter gray on hover/focus */
+    }
+
+    .navbar-default .navbar-nav > li > a {
+        color: #ced4da; /* Light gray for nav links */
+    }
+
+    .navbar-default .navbar-nav > li > a:hover,
+    .navbar-default .navbar-nav > li > a:focus {
+        color: #f8f9fa; /* White/very light gray on hover/focus */
+        background-color: #495057; /* Slightly lighter dark shade for hover background */
+    }
+
+    .navbar-default .navbar-nav > .active > a,
+    .navbar-default .navbar-nav > .active > a:hover,
+    .navbar-default .navbar-nav > .active > a:focus {
+        color: #f8f9fa; /* White/very light gray for active link */
+        background-color: #495057; /* Slightly lighter dark shade for active background */
+    }
+    
+    .navbar-default .navbar-text {
+      color: #ced4da; /* Light gray for other navbar text */
+    }
+
+    .navbar-default .navbar-toggle {
+        border-color: #6c757d;
+    }
+    .navbar-default .navbar-toggle:hover,
+    .navbar-default .navbar-toggle:focus {
+        background-color: #495057;
+    }
+    .navbar-default .navbar-toggle .icon-bar {
+        background-color: #f8f9fa;
+    }
+
+    /* Modals */
+    .modal-content {
+        background-color: #343a40; /* Dark gray for modal content */
+        color: #e0e0e0; /* Light text for modal */
+        border-color: #454d55;
+    }
+
+    .modal-header {
+        border-bottom-color: #454d55;
+    }
+    .modal-header .close {
+        color: #f8f9fa;
+        text-shadow: 0 1px 0 #000;
+    }
+    .modal-header .close:hover,
+    .modal-header .close:focus {
+        color: #ced4da;
+    }
+
+
+    .modal-footer {
+        border-top-color: #454d55;
+    }
+
+    /* Form Controls */
+    .form-control {
+        background-color: #495057; /* Darker input background */
+        color: #e0e0e0; /* Light text for inputs */
+        border-color: #6c757d; /* Mid-gray border */
+    }
+
+    .form-control:focus {
+        background-color: #495057; /* Keep dark background on focus */
+        color: #e0e0e0;
+        border-color: #80bdff; /* Bootstrap's default focus blue, can be adjusted */
+        box-shadow: 0 0 0 0.2rem rgba(0,123,255,.25); /* Standard focus shadow */
+    }
+    
+    .form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control {
+        background-color: #343a40;
+        opacity: 0.7;
+    }
+
+    select.form-control {
+        /* Specific overrides for select if needed, often harder to style consistently */
+    }
+    
+    textarea.form-control {
+       /* Specific overrides for textarea if needed */
+    }
+    
+    .form-control-static { /* For static text in forms, like #selectedDateDisplay */
+        color: #e0e0e0;
+    }
+
+
+    /* Buttons */
+    .btn-default,
+    .btn-secondary {
+        background-color: #6c757d; /* Mid-gray */
+        border-color: #60676d;
+        color: #f8f9fa; /* White text */
+    }
+
+    .btn-default:hover,
+    .btn-default:focus,
+    .btn-default:active,
+    .btn-secondary:hover,
+    .btn-secondary:focus,
+    .btn-secondary:active {
+        background-color: #545b62; /* Darker gray */
+        border-color: #4e555b;
+        color: #f8f9fa;
+    }
+
+    .btn-primary {
+        background-color: #007bff; /* Keep primary color distinct */
+        border-color: #007bff;
+        color: #ffffff;
+    }
+
+    .btn-primary:hover,
+    .btn-primary:focus,
+    .btn-primary:active {
+        background-color: #0056b3;
+        border-color: #0056b3;
+        color: #ffffff;
+    }
+    
+    .btn-info {
+        background-color: #17a2b8; /* Default Bootstrap info */
+        border-color: #17a2b8;
+        color: #ffffff;
+    }
+    .btn-info:hover, .btn-info:focus, .btn-info:active {
+        background-color: #117a8b;
+        border-color: #10707f;
+        color: #ffffff;
+    }
+
+
+    /* Panels (used in all_events.html) */
+    .panel-default {
+        background-color: #2c3034; /* Darker panel background */
+        border-color: #454d55;
+        color: #e0e0e0; /* Light text for panel content */
+    }
+
+    .panel-default > .panel-heading {
+        background-color: #343a40; /* Slightly lighter dark for panel heading */
+        border-color: #454d55;
+        color: #f8f9fa; /* Light text for panel title */
+    }
+    
+    .panel-default > .panel-body {
+        color: #e0e0e0; /* Ensure panel body text is light */
+    }
+    
+    .panel-footer {
+      background-color: #343a40;
+      border-top-color: #454d55;
+    }
+
+    /* List Group Items */
+    .list-group-item {
+        background-color: #343a40; /* Dark background for list items */
+        border-color: #454d55;
+        color: #e0e0e0; /* Light text */
+    }
+
+    a.list-group-item,
+    button.list-group-item {
+        color: #e0e0e0;
+    }
+    
+    a.list-group-item:hover,
+    button.list-group-item:hover,
+    a.list-group-item:focus,
+    button.list-group-item:focus {
+        background-color: #495057; /* Lighter dark for hover/focus */
+        color: #f8f9fa;
+    }
+
+    .list-group-item.active,
+    .list-group-item.active:hover,
+    .list-group-item.active:focus {
+        background-color: #007bff; /* Primary color for active item */
+        border-color: #007bff;
+        color: #ffffff;
+    }
+    .list-group-item.active .list-group-item-text,
+    .list-group-item.active:hover .list-group-item-text,
+    .list-group-item.active:focus .list-group-item-text {
+      color: #cce5ff; /* Lighter text for active items if needed */
+    }
+    
+    /* Alerts - Adjusting for dark theme */
+    .alert-success {
+        color: #d4edda;
+        background-color: #155724; /* Dark green background */
+        border-color: #1c7430;
+    }
+
+    .alert-info {
+        color: #d1ecf1;
+        background-color: #0c5460; /* Dark blue background */
+        border-color: #0e6e81;
+    }
+
+    .alert-warning {
+        color: #fff3cd;
+        background-color: #856404; /* Dark yellow/orange background */
+        border-color: #aa8205;
+    }
+
+    .alert-danger {
+        color: #f8d7da;
+        background-color: #721c24; /* Dark red background */
+        border-color: #8f242e;
+    }
+    
+    /* Specific Overrides for sticky filter if needed */
+    #filter-questions-section.sticky {
+        background-color: #2c3034; /* Dark background for sticky filter */
+        border-bottom-color: #454d55;
+    }
+
+    /* Dropdown menus */
+    .dropdown-menu {
+        background-color: #343a40;
+        border-color: #454d55;
+    }
+    .dropdown-menu > li > a {
+        color: #ced4da;
+    }
+    .dropdown-menu > li > a:hover,
+    .dropdown-menu > li > a:focus {
+        color: #f8f9fa;
+        background-color: #495057;
+    }
+    .dropdown-menu > .active > a,
+    .dropdown-menu > .active > a:hover,
+    .dropdown-menu > .active > a:focus {
+        color: #f8f9fa;
+        background-color: #007bff;
+    }
+    .dropdown-menu .divider {
+        background-color: #454d55;
+    }
+
+    /* Navbar Mobile Dropdown Legibility Fix - Dark Theme */
+    @media (max-width: 767px) {
+        .navbar-default .navbar-collapse.in .navbar-nav > .open > .dropdown-menu > li > a,
+        .navbar-default .navbar-nav .open .dropdown-menu > li > a { /* Added for collapsed state */
+            color: #ced4da !important;
+            background-color: #343a40 !important; /* Ensure links in dropdown have dark background */
+        }
+
+        .navbar-default .navbar-collapse.in .navbar-nav > .open > .dropdown-menu > li > a:hover,
+        .navbar-default .navbar-collapse.in .navbar-nav > .open > .dropdown-menu > li > a:focus,
+        .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover,
+        .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
+            color: #f8f9fa !important;
+            background-color: #495057 !important;
+        }
+
+        .navbar-default .navbar-collapse.in .navbar-nav > .open > .dropdown-menu > .active > a,
+        .navbar-default .navbar-collapse.in .navbar-nav > .open > .dropdown-menu > .active > a:hover,
+        .navbar-default .navbar-collapse.in .navbar-nav > .open > .dropdown-menu > .active > a:focus,
+        .navbar-default .navbar-nav .open .dropdown-menu > .active > a,
+        .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover,
+        .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus {
+            color: #f8f9fa !important;
+            background-color: #007bff !important;
+        }
+    }
+    
+    /* Ensure strong tags are legible in dark theme */
+    strong, .event-list-container .event-item .panel-body p strong {
+        color: #f0f0f0; /* Lighter color for strong tags */
+    }
+
+    /* Datepickk specific adjustments if needed - example for header */
+    #Datepickk .d-header {
+        background-color: #2c3034; /* Darker header for datepicker */
+        color: #f8f9fa;
+    }
+    #Datepickk .d-header i#d-previous:before {
+        border-right-color: #f8f9fa;
+    }
+    #Datepickk .d-header i#d-previous:after {
+        border-right-color: #2c3034;
+    }
+    #Datepickk .d-header i#d-next:before {
+        border-left-color: #f8f9fa;
+    }
+    #Datepickk .d-header i#d-next:after {
+        border-left-color: #2c3034;
+    }
+    #Datepickk .d-week {
+        background-color: #007bff; /* Example: Use primary color for week headers */
+        color: #ffffff;
+    }
+    #Datepickk .d-calendar {
+        background-color: #2c3034; /* Dark background for calendar body */
+        color: #e0e0e0;
+    }
+    #Datepickk .d-table input + label { /* Date cells */
+        color: #e0e0e0;
+    }
+    #Datepickk .d-table input + label.next,
+    #Datepickk .d-table input + label.prev { /* Next/Prev month dates */
+        color: #6c757d; 
+    }
+    #Datepickk .d-tables:not(.locked) input:not(:checked) + label:not(.hidden):hover {
+        background-color: #495057; /* Hover for date cells */
+        color: #f8f9fa;
+    }
+    #Datepickk .d-table input:checked + label { /* Selected date */
+        background-color: #007bff;
+        color: #ffffff;
+    }
+    #Datepickk .d-table input:checked + label:before { /* Range start/end selection indicator */
+        background-color: #0056b3;
+    }
+     #Datepickk .d-tables.range:not(.before) input:not(.single):checked + label ~ label:not(.hidden):before { /* Range middle selection indicator */
+        background-color: rgba(0, 123, 255, 0.5);
+    }
+    #Datepickk .d-table input + label.d-hidden { /* Hidden/unavailable dates */
+        color: #495057 !important;
+        background: #212529 !important;
+    }
+    #Datepickk .d-legend p {
+        color: #e0e0e0;
+        background-color: #2c3034;
+    }
+    #Datepickk .d-legend {
+         background-color: #2c3034;
+    }
+    #Datepickk .d-confirm, #Datepickk .d-title {
+        color: #f8f9fa; /* Light text for confirm/title if they were dark */
+    }
+
+
+    /* Flat Timetable specific adjustments */
+    .flat-timetable table {
+        color: #e0e0e0; /* Light text for timetable */
+    }
+    .flat-timetable table tr:nth-child(2n) {
+        background: #2c3034; /* Darker alternating row */
+    }
+    .flat-timetable table tr:nth-child(2n+3) {
+        background: #343a40; /* Lighter dark alternating row */
+    }
+    .flat-timetable .days, .flat-timetable .time, .flat-timetable .title {
+        background: #007bff; /* Using primary blue for headers */
+        color: #ffffff;
+    }
+
+}


### PR DESCRIPTION
 Ajustei o CSS dos campos de entrada no modal de evento (hora, descrição, lembrete) para melhor atender às necessidades de conteúdo.
    Implementei um tema de modo escuro usando a media query @media (prefers-color-scheme: dark) em css/main-theme.css.
    Os estilos do modo escuro abrangem o corpo, barra de navegação, modais, formulários, botões, painéis, grupos de listas e alertas.
    Garanti que o texto tenha bom contraste e corrigi o problema de áreas brancas permanecendo na página no modo escuro.
