### PR TITLE
Fix: Correct chat window background in dark theme

### DIFF
--- a/css/main-theme.css
+++ b/css/main-theme.css
@@ -637,9 +637,9 @@ body {
     }
 
     /* Chat-specific styles */
-    #chat-view .panel-body {
-        background-color: #2c3034; /* Darker background for chat messages */
-        color: #f1ac0b; /* Light text color for better contrast */
+    #chat-view .panel.panel-default .panel-body {
+        background-color: #2c3034 !important; /* Darker background for chat messages */
+        color: #f1ac0b !important; /* Light text color for better contrast */
     }
 
     .message.user {


### PR DESCRIPTION
This commit fixes an issue where the chat window background was not being themed correctly in dark mode. A more specific selector has been added to `main-theme.css` to ensure the dark theme is applied correctly.

This commit also includes the previous refactoring work to consolidate CSS and implement light and dark themes.